### PR TITLE
display correctly international characters

### DIFF
--- a/src/main/resources/org/concordion/ext/loggingFormatter/LogViewer.html
+++ b/src/main/resources/org/concordion/ext/loggingFormatter/LogViewer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <head>
 <style type="text/css">
 	h1 {


### PR DESCRIPTION
At the moment international characters such as Spanish accented letters are display wrong.
